### PR TITLE
Update kubi-cli.go

### DIFF
--- a/kubi-cli.go
+++ b/kubi-cli.go
@@ -109,6 +109,7 @@ func main() {
 	if *generateConfig {
 		user, err := user.Current()
 		check(err)
+		os.MkdirAll(user.HomeDir + "/.kube", 0600)
 		f, err := os.Create(user.HomeDir + "/.kube/config")
 		check(err)
 		f.Write(tokenbody)


### PR DESCRIPTION
Fixed an issue with the windows executable when the folder ".kube" doesn't exist