### PR TITLE
Remove color when output device is not a terminal

### DIFF
--- a/internals/logger.go
+++ b/internals/logger.go
@@ -2,15 +2,26 @@ package internal
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
+func isTerminal() bool {
+	fileInfo, _ := os.Stdout.Stat()
+	return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}
+
 func LogWhite(msg ...string) {
 	coloredLog("97", msg...)
+
 }
 
 func LogYellow(msg ...string) {
 	coloredLog("33", msg...)
+}
+
+func LogBlue(msg ...string) {
+	coloredLog("36", msg...)
 }
 
 func LogLightGray(msg ...string) {
@@ -34,5 +45,9 @@ func LogRed(msg ...string) {
 }
 
 func coloredLog(color string, msg ...string) {
-	fmt.Printf("\033[1;"+color+"m%v\033[0m\n", strings.Join(msg, ""))
+	if isTerminal() {
+		fmt.Printf("\033[1;"+color+"m%v\033[0m\n", strings.Join(msg, ""))
+	} else {
+		fmt.Println(strings.Join(msg, ""))
+	}
 }


### PR DESCRIPTION
Bonjour,

PR pour enlever les couleurs lorsque l'output device n'est pas un terminal.
Cela permet de travailler avec un output propre lorsqu'on a besoin de `| grep ...` par exemple.

J'en ai profité pour corriger une typo et renommer kubiUrl en kubiURL.

Dimitri